### PR TITLE
Confirm before training / dismissal to prevent accidental actions (#5)

### DIFF
--- a/gui/HelperPersonnelFrame.lua
+++ b/gui/HelperPersonnelFrame.lua
@@ -358,6 +358,81 @@ function HelperPersonnelFrame:showApplicantsView()
     self:updateButtons()
 end
 
+-- Show a Yes/No confirmation before a destructive action (dismissal / training),
+-- then run onConfirm only if the player confirms. Guards accidental key/button
+-- presses (issue #5). Falls back to running directly if the dialog is unavailable,
+-- so behaviour never breaks. Static so other files (training) can reuse it.
+function HelperPersonnelFrame.showConfirmationDialog(text, onConfirm)
+    if text == nil or text == "" then
+        if onConfirm ~= nil then
+            onConfirm()
+        end
+        return
+    end
+
+    if g_gui ~= nil and g_gui.showYesNoDialog ~= nil then
+        g_gui:showYesNoDialog({
+            text = text,
+            callback = function(yes)
+                if yes == true and onConfirm ~= nil then
+                    onConfirm()
+                end
+            end
+        })
+        return
+    end
+
+    if onConfirm ~= nil then
+        onConfirm()
+    end
+end
+
+function HelperPersonnelFrame:getWorkerDisplayName(worker)
+    if worker == nil then
+        return ""
+    end
+
+    local manager = self:getManager()
+    if manager ~= nil and manager.getFullName ~= nil then
+        local ok, name = pcall(manager.getFullName, manager, worker)
+        if ok and name ~= nil and name ~= "" then
+            return name
+        end
+    end
+
+    local firstName = worker.firstName or ""
+    local lastName = worker.lastName or ""
+    local name = string.format("%s %s", firstName, lastName)
+    if name ~= " " then
+        return name
+    end
+
+    return tostring(worker.id or "")
+end
+
+function HelperPersonnelFrame:performDismissWorker(worker)
+    local manager = self:getManager()
+    if worker == nil or manager == nil then
+        return
+    end
+
+    if self.app ~= nil and self.app.requestDismissWorker ~= nil then
+        self.app:requestDismissWorker(worker.id)
+    else
+        manager:dismissWorker(worker.id)
+    end
+
+    local workers = self:getWorkers()
+    if #workers == 0 then
+        self:showOverview()
+    else
+        self.workerIndex = hpClamp(self.workerIndex, 1, #workers)
+    end
+
+    self:refresh()
+    self:updateButtons()
+end
+
 function HelperPersonnelFrame:activateCurrentEntry()
     local manager = self:getManager()
     if manager == nil then
@@ -372,18 +447,11 @@ function HelperPersonnelFrame:activateCurrentEntry()
         end
 
         local worker = workers[self.workerIndex]
-        if self.app ~= nil and self.app.requestDismissWorker ~= nil then
-            self.app:requestDismissWorker(worker.id)
-        else
-            manager:dismissWorker(worker.id)
-        end
-        workers = self:getWorkers()
-
-        if #workers == 0 then
-            self:showOverview()
-        else
-            self.workerIndex = hpClamp(self.workerIndex, 1, #workers)
-        end
+        local text = string.format(self:getText("ui_confirmDismissText", "Do you really want to dismiss %s?"), self:getWorkerDisplayName(worker))
+        HelperPersonnelFrame.showConfirmationDialog(text, function()
+            self:performDismissWorker(worker)
+        end)
+        return
     elseif self.mode == HelperPersonnelFrame.MODE_APPLICANTS then
         local applicants = self:getApplicants()
         if #applicants == 0 then

--- a/i18n/l10n_de.xml
+++ b/i18n/l10n_de.xml
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <l10n>
     <elements>
+        <e k="ui_confirmDismissText" v="Willst du %s wirklich entlassen?" />
+        <e k="ui_confirmTrainText" v="%s in die Schulung schicken? Während der Schulung kann der Mitarbeiter nicht für Feldarbeit eingeteilt werden." />
         <e k="ui_ingameMenuHelperPersonnel" v="Personalmanagement" />
         <e k="ui_workersHeader" v="Mitarbeiter" />
         <e k="ui_applicantsHeader" v="Bewerbermarkt" />

--- a/i18n/l10n_en.xml
+++ b/i18n/l10n_en.xml
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <l10n>
     <elements>
+        <e k="ui_confirmDismissText" v="Do you really want to dismiss %s?" />
+        <e k="ui_confirmTrainText" v="Send %s to training? They cannot be assigned to field work while in training." />
         <e k="ui_ingameMenuHelperPersonnel" v="Personnel Management" />
         <e k="ui_workersHeader" v="Employees" />
         <e k="ui_applicantsHeader" v="Applicants" />

--- a/scripts/HelperPersonnelExperienceEffects.lua
+++ b/scripts/HelperPersonnelExperienceEffects.lua
@@ -1550,10 +1550,9 @@ if HelperPersonnelFrame ~= nil then
         return worker
     end
 
-    function HelperPersonnelFrame:onClickTrainWorker()
-        local worker = self:getSelectedWorkerForTrainingAction()
+    function HelperPersonnelFrame:performTrainWorker(worker)
         if worker == nil then
-            return false
+            return
         end
 
         local changed = false
@@ -1571,6 +1570,26 @@ if HelperPersonnelFrame ~= nil then
             if self.updateButtons ~= nil then
                 self:updateButtons()
             end
+        end
+    end
+
+    function HelperPersonnelFrame:onClickTrainWorker()
+        local worker = self:getSelectedWorkerForTrainingAction()
+        if worker == nil then
+            return false
+        end
+
+        -- Confirm before sending to training so an accidental S key press can't
+        -- silently pull an employee off field work (issue #5).
+        local workerName = self.getWorkerDisplayName ~= nil and self:getWorkerDisplayName(worker) or tostring(worker.id or "")
+        local text = string.format(self:getText("ui_confirmTrainText", "Send %s to training? They cannot be assigned to field work while in training."), workerName)
+
+        if HelperPersonnelFrame.showConfirmationDialog ~= nil then
+            HelperPersonnelFrame.showConfirmationDialog(text, function()
+                self:performTrainWorker(worker)
+            end)
+        else
+            self:performTrainWorker(worker)
         end
 
         return true


### PR DESCRIPTION
Fixes the *accidental training / dismissal* part of #5.

## Problem
Dismissal (Enter / Execute) and training (S key) execute immediately, so an unintended key press can silently fire an employee or pull them off field work — exactly what @NongDeChuanRen reported.

## Change
A Yes/No confirmation dialog now appears before either action; the employee is only dismissed / sent to training if the player confirms.

- `HelperPersonnelFrame.showConfirmationDialog(text, onConfirm)` — small shared helper around `g_gui:showYesNoDialog`. If the dialog is somehow unavailable it falls back to running the action directly, so behaviour never breaks.
- Dismissal (`activateCurrentEntry`) and training (`onClickTrainWorker`) route through it; the actual logic is unchanged, just extracted into `performDismissWorker` / `performTrainWorker`.
- Hiring is left one-click (not part of the report).

## Scope / safety
- **UI-only** — no network/server, savegame or MP logic touched, so it shouldn't collide with your MP work (#1) or the new standalone menu (#6). Intended as an interim safety guard for the current menu.
- New l10n keys `ui_confirmDismissText` / `ui_confirmTrainText` added for **en + de**; other languages fall back to English via `getText(key, fallback)` and can be localised later.

Both edited files pass a Lua `load()` syntax check and both l10n files are valid XML. I couldn't test in-game on my side — a quick check that the dialog shows and confirm/cancel behave would be worth it before merge.

Thanks for the mod! :)